### PR TITLE
Ajusta CI/CD para rodar apenas em PROD

### DIFF
--- a/.github/workflows/carros-ci-cd.yml
+++ b/.github/workflows/carros-ci-cd.yml
@@ -3,16 +3,14 @@ name: CI/CD carros
 on:
   push:
     branches:
-      - dev
-      - prod
+      - prod   # corrigido: removido dev
     paths:
       - 'carros/**'
       - '.github/workflows/carros-ci-cd.yml'
 
   pull_request:
     branches:
-      - dev
-      - prod
+      - prod   # corrigido: removido dev
     paths:
       - 'carros/**'
       - '.github/workflows/carros-ci-cd.yml'
@@ -50,43 +48,8 @@ jobs:
       - name: Validar autenticação Databricks
         run: databricks current-user me
 
-      - name: Validar bundle carros DEV
-        run: databricks bundle validate -t dev
-
       - name: Validar bundle carros PROD
-        run: databricks bundle validate -t prod
-
-  deploy-carros-dev:
-    name: Deploy carros DEV
-    runs-on: ubuntu-latest
-    needs: validate-carros
-    if: github.ref == 'refs/heads/dev' && github.event_name != 'pull_request'
-
-    env:
-      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
-      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
-
-    defaults:
-      run:
-        working-directory: carros
-
-    steps:
-      - name: Checkout código
-        uses: actions/checkout@v4
-
-      - name: Instalar Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Instalar Databricks CLI
-        uses: databricks/setup-cli@v0.278.0
-
-      - name: Instalar uv
-        run: python -m pip install uv
-
-      - name: Deploy bundle carros em DEV
-        run: databricks bundle deploy -t dev --auto-approve
+        run: databricks bundle validate -t prod   # corrigido: removida validação dev
 
   deploy-carros-prod:
     name: Deploy carros PROD

--- a/.github/workflows/pokemon-ci-cd.yml
+++ b/.github/workflows/pokemon-ci-cd.yml
@@ -1,4 +1,4 @@
-name: CI/CD carros
+name: CI/CD pokemon
 
 on:
   push:

--- a/.github/workflows/pokemon-ci-cd.yml
+++ b/.github/workflows/pokemon-ci-cd.yml
@@ -1,27 +1,25 @@
-name: CI/CD pokemon
+name: CI/CD pokemon   # corrigido: mantido pokemon
 
 on:
   push:
     branches:
-      - dev
-      - prod
+      - prod   # corrigido: removido dev
     paths:
-      - 'carros/**'
-      - '.github/workflows/carros-ci-cd.yml'
+      - 'pokemon/**'   # corrigido: era carros/**
+      - '.github/workflows/pokemon-ci-cd.yml'   # corrigido: era carros-ci-cd.yml
 
   pull_request:
     branches:
-      - dev
-      - prod
+      - prod   # corrigido: removido dev
     paths:
-      - 'carros/**'
-      - '.github/workflows/carros-ci-cd.yml'
+      - 'pokemon/**'   # corrigido: era carros/**
+      - '.github/workflows/pokemon-ci-cd.yml'   # corrigido: era carros-ci-cd.yml
 
   workflow_dispatch:
 
 jobs:
-  validate-carros:
-    name: Validar bundle carros
+  validate-pokemon:   # corrigido: era validate-carros
+    name: Validar bundle pokemon   # corrigido: era carros
     runs-on: ubuntu-latest
 
     env:
@@ -30,7 +28,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: carros
+        working-directory: pokemon   # corrigido: era carros
 
     steps:
       - name: Checkout código
@@ -50,51 +48,13 @@ jobs:
       - name: Validar autenticação Databricks
         run: databricks current-user me
 
-      - name: Validar bundle carros DEV
-        run: databricks bundle validate -t dev
-
-      - name: Validar bundle carros PROD
+      - name: Validar bundle pokemon PROD   # corrigido: removida validação dev e trocado carros por pokemon
         run: databricks bundle validate -t prod
 
-  deploy-carros-dev:
-    name: Deploy carros DEV
+  deploy-pokemon-prod:   # corrigido: era deploy-carros-prod
+    name: Deploy pokemon PROD   # corrigido: era carros
     runs-on: ubuntu-latest
-    needs: validate-carros
-    if: github.ref == 'refs/heads/dev' && github.event_name != 'pull_request'
-
-    env:
-      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
-      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
-
-    defaults:
-      run:
-        working-directory: carros
-
-    steps:
-      - name: Checkout código
-        uses: actions/checkout@v4
-
-      - name: Instalar Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Instalar Databricks CLI
-        uses: databricks/setup-cli@v0.278.0
-
-      - name: Instalar uv
-        run: python -m pip install uv
-
-      - name: Deploy bundle carros em DEV
-        run: databricks bundle deploy -t dev --auto-approve
-
-      - name: Rodar job carros em DEV
-        run: databricks bundle run -t dev carros_job
-
-  deploy-carros-prod:
-    name: Deploy carros PROD
-    runs-on: ubuntu-latest
-    needs: validate-carros
+    needs: validate-pokemon   # corrigido: era validate-carros
     if: github.ref == 'refs/heads/prod' && github.event_name != 'pull_request'
 
     env:
@@ -103,7 +63,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: carros
+        working-directory: pokemon   # corrigido: era carros
 
     steps:
       - name: Checkout código
@@ -120,8 +80,8 @@ jobs:
       - name: Instalar uv
         run: python -m pip install uv
 
-      - name: Deploy bundle carros em PROD
+      - name: Deploy bundle pokemon em PROD   # corrigido: era carros
         run: databricks bundle deploy -t prod --auto-approve
 
-      - name: Rodar job carros em PROD
-        run: databricks bundle run -t prod carros_job
+      - name: Rodar job pokemon em PROD   # corrigido: era carros
+        run: databricks bundle run -t prod pokemon_job   # corrigido: era carros_job

--- a/carros/resources/carros_job.job.yml
+++ b/carros/resources/carros_job.job.yml
@@ -9,7 +9,6 @@ resources:
       schedule:
         quartz_cron_expression: "0 0 01 * * ?"
         timezone_id: "America/Sao_Paulo"
-        pause_status: PAUSED
 
       parameters:
         - name: environment

--- a/pokemon/resources/pokemon.job.yml
+++ b/pokemon/resources/pokemon.job.yml
@@ -9,7 +9,6 @@ resources:
       schedule:
         quartz_cron_expression: "0 0 01 * * ?"
         timezone_id: "America/Sao_Paulo"
-        pause_status: PAUSED
 
       parameters:
         - name: environment


### PR DESCRIPTION
Ajusta os workflows de CI/CD dos projetos carros e pokemon para rodarem apenas em PROD.

Alterações:
- remoção do deploy DEV
- remoção da validação DEV
- ajuste dos paths do workflow pokemon
- correção do working-directory do pokemon
- execução apenas na branch prod